### PR TITLE
Suggestion for some nbt storage optimization

### DIFF
--- a/libs/crafter/data/smithed.crafter/functions/impl/__version__/block/table/crafting/input/read_barrel.mcfunction
+++ b/libs/crafter/data/smithed.crafter/functions/impl/__version__/block/table/crafting/input/read_barrel.mcfunction
@@ -7,15 +7,15 @@ scoreboard players set @s smithed.data 0
 
 data modify storage smithed.crafter:main root.temp.crafting_input_temp set value [[{id:"minecraft:air"},{id:"minecraft:air"},{id:"minecraft:air"}],[{id:"minecraft:air"},{id:"minecraft:air"},{id:"minecraft:air"}],[{id:"minecraft:air"},{id:"minecraft:air"},{id:"minecraft:air"}]]
 
-execute if data block ~ ~ ~ Items[{Slot:2b}] run data modify storage smithed.crafter:main root.temp.crafting_input_temp[0][0] set from block ~ ~ ~ Items[{Slot:2b}]
-execute if data block ~ ~ ~ Items[{Slot:3b}] run data modify storage smithed.crafter:main root.temp.crafting_input_temp[0][1] set from block ~ ~ ~ Items[{Slot:3b}]
-execute if data block ~ ~ ~ Items[{Slot:4b}] run data modify storage smithed.crafter:main root.temp.crafting_input_temp[0][2] set from block ~ ~ ~ Items[{Slot:4b}]
-execute if data block ~ ~ ~ Items[{Slot:11b}] run data modify storage smithed.crafter:main root.temp.crafting_input_temp[1][0] set from block ~ ~ ~ Items[{Slot:11b}]
-execute if data block ~ ~ ~ Items[{Slot:12b}] run data modify storage smithed.crafter:main root.temp.crafting_input_temp[1][1] set from block ~ ~ ~ Items[{Slot:12b}]
-execute if data block ~ ~ ~ Items[{Slot:13b}] run data modify storage smithed.crafter:main root.temp.crafting_input_temp[1][2] set from block ~ ~ ~ Items[{Slot:13b}]
-execute if data block ~ ~ ~ Items[{Slot:20b}] run data modify storage smithed.crafter:main root.temp.crafting_input_temp[2][0] set from block ~ ~ ~ Items[{Slot:20b}]
-execute if data block ~ ~ ~ Items[{Slot:21b}] run data modify storage smithed.crafter:main root.temp.crafting_input_temp[2][1] set from block ~ ~ ~ Items[{Slot:21b}]
-execute if data block ~ ~ ~ Items[{Slot:22b}] run data modify storage smithed.crafter:main root.temp.crafting_input_temp[2][2] set from block ~ ~ ~ Items[{Slot:22b}]
+execute if data storage smithed.crafter:main root.Items[{Slot:2b}] run data modify storage smithed.crafter:main root.temp.crafting_input_temp[0][0] set from storage smithed.crafter:main root.Items[{Slot:2b}]
+execute if data storage smithed.crafter:main root.Items[{Slot:3b}] run data modify storage smithed.crafter:main root.temp.crafting_input_temp[0][1] set from storage smithed.crafter:main root.Items[{Slot:3b}]
+execute if data storage smithed.crafter:main root.Items[{Slot:4b}] run data modify storage smithed.crafter:main root.temp.crafting_input_temp[0][2] set from storage smithed.crafter:main root.Items[{Slot:4b}]
+execute if data storage smithed.crafter:main root.Items[{Slot:11b}] run data modify storage smithed.crafter:main root.temp.crafting_input_temp[1][0] set from storage smithed.crafter:main root.Items[{Slot:11b}]
+execute if data storage smithed.crafter:main root.Items[{Slot:12b}] run data modify storage smithed.crafter:main root.temp.crafting_input_temp[1][1] set from storage smithed.crafter:main root.Items[{Slot:12b}]
+execute if data storage smithed.crafter:main root.Items[{Slot:13b}] run data modify storage smithed.crafter:main root.temp.crafting_input_temp[1][2] set from storage smithed.crafter:main root.Items[{Slot:13b}]
+execute if data storage smithed.crafter:main root.Items[{Slot:20b}] run data modify storage smithed.crafter:main root.temp.crafting_input_temp[2][0] set from storage smithed.crafter:main root.Items[{Slot:20b}]
+execute if data storage smithed.crafter:main root.Items[{Slot:21b}] run data modify storage smithed.crafter:main root.temp.crafting_input_temp[2][1] set from storage smithed.crafter:main root.Items[{Slot:21b}]
+execute if data storage smithed.crafter:main root.Items[{Slot:22b}] run data modify storage smithed.crafter:main root.temp.crafting_input_temp[2][2] set from storage smithed.crafter:main root.Items[{Slot:22b}]
 
 function smithed.crafter:impl/__version__/block/table/crafting/input/handle_tags
 

--- a/libs/crafter/data/smithed.crafter/functions/impl/__version__/block/table/crafting/manage_invalids/export_output.mcfunction
+++ b/libs/crafter/data/smithed.crafter/functions/impl/__version__/block/table/crafting/manage_invalids/export_output.mcfunction
@@ -6,7 +6,7 @@ scoreboard players reset @s smithed.data
 # Recreate the output and check if it's the same thing, if so add a tag to invalidate shift-clicking
 
 data modify storage smithed.crafter:main root.temp.export_items set value []
-data modify storage smithed.crafter:main root.temp.export_items append from block ~ ~ ~ Items[{Slot:16b}]
+data modify storage smithed.crafter:main root.temp.export_items append from storage smithed.crafter:main root.Items[{Slot:16b}]
 
 function smithed.crafter:impl/__version__/block/table/crafting/input/read_barrel
 data modify storage smithed.crafter:main root.temp.item set from block ~ ~ ~ Items[{Slot:16b}]

--- a/libs/crafter/data/smithed.crafter/functions/impl/__version__/block/table/open_tick.mcfunction
+++ b/libs/crafter/data/smithed.crafter/functions/impl/__version__/block/table/open_tick.mcfunction
@@ -7,11 +7,14 @@ execute if entity @s[predicate=smithed.crafter:block/table/invalid_items] run fu
 
 # Output Management
 
+## Copy block content into a storage for nbt manipulation
+data modify storage smithed.crafter:main root.Items set from block ~ ~ ~ Items
+
 ## If output changed from full to full or empty to full, set score (Also copies tags into this entity)
-execute store success score @s smithed.data run data modify entity @s ArmorItems[3].tag.smithed.stored_output set from block ~ ~ ~ Items[{Slot:16b}]
+execute store success score @s smithed.data run data modify entity @s ArmorItems[3].tag.smithed.stored_output set from storage smithed.crafter:main root.Items[{Slot:16b}]
 
 ## If the output changed from full to empty, set score
-execute store success score @s smithed.data unless block ~ ~ ~ barrel{Items:[{Slot:16b}]} if data entity @s ArmorItems[3].tag.smithed.stored_output.id run data modify entity @s ArmorItems[3].tag.smithed.stored_output set value {Slot:16b}
+execute store success score @s smithed.data unless data storage smithed.crafter:main root.Items[{Slot:16b}] if data entity @s ArmorItems[3].tag.smithed.stored_output.id run data modify entity @s ArmorItems[3].tag.smithed.stored_output set value {Slot:16b}
 
 ## If the score changed, run update output commands
 execute if entity @s[scores={smithed.data=1..}] run function smithed.crafter:impl/__version__/block/table/crafting/output/check

--- a/libs/crafter/data/smithed.crafter/functions/impl/__version__/technical/tick.mcfunction
+++ b/libs/crafter/data/smithed.crafter/functions/impl/__version__/technical/tick.mcfunction
@@ -1,3 +1,3 @@
-execute as @e[tag=smithed.crafter] at @s run function smithed.crafter:impl/__version__/block/table/tick
+execute as @e[type=armor_stand,tag=smithed.crafter] at @s run function smithed.crafter:impl/__version__/block/table/tick
 
 schedule function smithed.crafter:impl/__version__/technical/tick 1t replace


### PR DESCRIPTION
I found some optimizations that can be helpful about how the Smithed Crafter is working.

Firstly, I noticed an untyped `@e` for the call of the Smithed Table located [here](https://github.com/Smithed-MC/Libraries/blob/main/libs/crafter/data/smithed.crafter/functions/impl/__version__/technical/tick.mcfunction)

Secondly, I also noticed that you are using a lot of block checking that call a Minecraft internal event called `#getChunk` which has its cost.
A solution, and what I suggest you, is to copy the entire Items nbt list of the block once into a storage to prevent calling this internal event that we should avoid.
So I started it in this pull request for most called commands.


This topic came up in a conversation with a friend who also made a custom crafting table and saying that the Smithed one wasn't optimized enough. Some other people in the future can be unattractive to this, even if it is only a very small minority.
That why I suggested you these optimizations tricks.

I hope you take time to read and think about this.

Best regards,

Alexandre
