### PR TITLE
More Complete Versioning

### DIFF
--- a/libs/custom-block/data/smithed.custom_block/advancements/impl/__version__/technical/place_custom_block.json
+++ b/libs/custom-block/data/smithed.custom_block/advancements/impl/__version__/technical/place_custom_block.json
@@ -1,22 +1,20 @@
 {
-    "__public__": true,
-    "criteria": {
-      "requirement": {
-        "trigger": "minecraft:placed_block",
-        "conditions": {
-          "item": {
-            "nbt": "{BlockEntityTag:{Items:[{tag:{smithed:{block:{}}}}]}}"
-          },
-          "location": {
-            "block": {
-              "tag": "smithed.custom_block:placeable"
-            }
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:placed_block",
+      "conditions": {
+        "item": {
+          "nbt": "{BlockEntityTag:{Items:[{tag:{smithed:{block:{}}}}]}}"
+        },
+        "location": {
+          "block": {
+            "tag": "smithed.custom_block:placeable"
           }
         }
       }
-    },
-    "rewards": {
-      "function": "smithed.custom_block:calls/__version__/place"
     }
+  },
+  "rewards": {
+    "function": "smithed.custom_block:impl/__version__/place"
   }
-  
+}

--- a/libs/custom-block/data/smithed.custom_block/functions/impl/__version__/place.mcfunction
+++ b/libs/custom-block/data/smithed.custom_block/functions/impl/__version__/place.mcfunction
@@ -1,5 +1,3 @@
-# @public
-
 advancement revoke @s only smithed.custom_block:impl/__version__/technical/place_custom_block
 
 execute align xyz positioned ~0.5 ~-6.5 ~0.5 run function smithed.custom_block:impl/__version__/place/layer

--- a/libs/damage/data/smithed.damage/advancements/impl/__version__/player/event.json
+++ b/libs/damage/data/smithed.damage/advancements/impl/__version__/player/event.json
@@ -1,5 +1,4 @@
 {
-	"__public__": true,
 	"criteria": {
 		"generic": {
 			"trigger": "minecraft:entity_hurt_player",
@@ -90,6 +89,6 @@
 		}
 	},
 	"rewards": {
-		"function": "smithed.damage:calls/__version__/player/event"
+		"function": "smithed.damage:impl/__version__/player/event"
 	}
 }

--- a/libs/damage/data/smithed.damage/functions/impl/__version__/player/event.mcfunction
+++ b/libs/damage/data/smithed.damage/functions/impl/__version__/player/event.mcfunction
@@ -1,5 +1,3 @@
-# @public
-
 # @doc player/damage_events
 # Player damage events happen when a player is damaged.
 # You can add damage events by adding your function to the tag `#smithed.damage:event/player/on_damage`.  


### PR DESCRIPTION
This PR fixes some versioning issues.
- `__version__` gets properly replaced in advancements, loot tables, tags, predicates, and recipes
- advancements will generate version checking; advancements should directly call an `impl` function, as version checking is done within the conditions
- `__public__` advancements are no longer a thing; advancements don't generate a `calls` function