### PR TITLE
Properly Clear Schedule Loops

### DIFF
--- a/default/versioning.py
+++ b/default/versioning.py
@@ -295,10 +295,7 @@ def run(ctx: Context):
     namespace: str = ctx.meta["versioning"]["namespace"]
     scoreholder: str = ctx.meta["versioning"]["scoreholder"]
     version_parts: list[str] = ctx.project_version.split(".")
-    try:
-        scheduled: list[str] = ctx.meta["scheduled"]
-    except:
-        scheduled = []
+    scheduled: list[str] = ctx.meta.get("scheduled", [])
 
     load_tags(ctx, namespace)
 

--- a/libs/actionbar/beet.yaml
+++ b/libs/actionbar/beet.yaml
@@ -23,3 +23,5 @@ meta:
   versioning:
     scoreholder: '#smithed.actionbar'
     namespace: smithed.actionbar
+  scheduled:
+    - tick

--- a/libs/crafter/beet.yaml
+++ b/libs/crafter/beet.yaml
@@ -28,3 +28,6 @@ meta:
   versioning:
     scoreholder: '#smithed.crafter'
     namespace: smithed.crafter
+  scheduled:
+    - tick
+    - slow_tick

--- a/libs/enchanter/beet.yaml
+++ b/libs/enchanter/beet.yaml
@@ -18,6 +18,9 @@ meta:
   versioning:
     scoreholder: '#smithed.enchanter'
     namespace: smithed.enchanter
+    
+  scheduled:
+    - tick
 
   dbg:
     enabled: false

--- a/libs/item/beet.yaml
+++ b/libs/item/beet.yaml
@@ -25,3 +25,5 @@ meta:
   versioning:
     scoreholder: '#smithed.item'
     namespace: smithed.item
+  scheduled:
+    - tick

--- a/libs/prevent-aggression/beet.yaml
+++ b/libs/prevent-aggression/beet.yaml
@@ -23,3 +23,5 @@ meta:
   versioning:
     scoreholder: '#smithed.prevent_aggression'
     namespace: smithed.prevent_aggression
+  scheduled:
+    - 10_tick


### PR DESCRIPTION
Previously it was hardcoded to `schedule clear` a tick function, but that doesn't exist for all libraries. Additionally it didn't clear any other schedule loops that aren't called tick.