### PR TITLE
feat(actionbar): priorities behavior altered + reset api

### DIFF
--- a/smithed_libraries/packs/actionbar/beet.yaml
+++ b/smithed_libraries/packs/actionbar/beet.yaml
@@ -8,3 +8,6 @@ description: Native Actionbar Library for Smithed
 data_pack:
   name: Smithed Actionbar
   load: .
+
+require:
+  - bolt

--- a/smithed_libraries/packs/actionbar/data/smithed.actionbar/functions/impl/reset.mcfunction
+++ b/smithed_libraries/packs/actionbar/data/smithed.actionbar/functions/impl/reset.mcfunction
@@ -1,3 +1,13 @@
+# @public
+
+# @doc reset
+# This function resets the current freeze and priority allowing you to display another message
+# ```{admonition} ⚠️ Caution ⚠️
+# :class: warning
+# This api **will** disrupt other packs as it blatently resets the actionbar state.
+# Do not use this in any normal circumstances, as it will break compatibility in most cases.
+# ```
+
 # resets player's actionbar scores so they can see any new actionbar
 # @s = player that has a freeze score of 1
 # located at @s

--- a/smithed_libraries/packs/actionbar/data/smithed.actionbar/functions/impl/technical/load.mcfunction
+++ b/smithed_libraries/packs/actionbar/data/smithed.actionbar/functions/impl/technical/load.mcfunction
@@ -3,6 +3,11 @@ scoreboard objectives add smithed.actionbar.const dummy
 scoreboard objectives add smithed.actionbar.priority dummy
 scoreboard objectives add smithed.actionbar.freeze dummy
 scoreboard objectives add smithed.actionbar.sleep_t dummy
+
+# We use score explicitly instead of sneaking predicate
+#  scores check for shift-key usage (intentional sneaking)
+#  predicates also check for force sneaking (like in 1x1 gap)
+# Score's catch some false negatives that predicates would miss
 scoreboard objectives add smithed.actionbar.sneaking minecraft.custom:minecraft.sneak_time
 
 scoreboard players set $default.freeze smithed.actionbar.const 20


### PR DESCRIPTION
- Messages with the same priority now override the displayed message.
  - Override priority messages do not follow such behavior
- `#smithed.actionbar:reset` new api for testers, etc.

Overall improved docs.