### PR TITLE
fix(versioning): Allows player condition in advancements to be a object

### DIFF
--- a/smithed_libraries/plugins/versioning/load.py
+++ b/smithed_libraries/plugins/versioning/load.py
@@ -98,6 +98,14 @@ def resolve_advancement(advancement: Advancement, opts: VersioningOptions):
         conditions = requirement.setdefault("conditions", {})
         player_conditions = conditions.setdefault("player", [])
 
+        if isinstance(player_conditions, dict):
+            player_conditions = [{
+                "condition": "minecraft:entity_properties",
+                "entity": "this",
+                "predicate": player_conditions
+            }]
+            conditions["player"] = player_conditions
+
         for name, number in opts.version.named_parts():
             scoreholder_part = f"{opts.scoreholder}.{name}"
             version_check = {


### PR DESCRIPTION
Convert dict player condition to proper `entity_properties` format before appending version checks.

Fixes #53 

If player condition is a object instead of a list, convert it to a entity property: 
```
[{
 "condition": "minecraft:entity_properties",
 "entity": "this",
 "predicate": {{player_conditions}}
}]