### PR TITLE
fix(actionbar): port vanilla interactions to 26.2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ on:
   workflow_dispatch:
 
 env:
-  MC_VERSION: '26.1'
+  MC_VERSION: '26.2'
   COMMIT_MSG: ${{ github.event.head_commit.message }}
 
 jobs:

--- a/smithed_libraries/packs/actionbar/beet.yaml
+++ b/smithed_libraries/packs/actionbar/beet.yaml
@@ -2,7 +2,7 @@ extend: "@smithed_libraries/common.yaml"
 
 id: smithed.actionbar
 name: Smithed Actionbar
-version: "0.7.0"
+version: "0.8.0"
 description: Native Actionbar Library for Smithed
 
 data_pack:

--- a/smithed_libraries/packs/actionbar/data/smithed.actionbar/advancement/impl/vanilla/bed/clicked_bed.json
+++ b/smithed_libraries/packs/actionbar/data/smithed.actionbar/advancement/impl/vanilla/bed/clicked_bed.json
@@ -1,7 +1,7 @@
 {
   "criteria": {
     "unoccupied": {
-      "trigger": "minecraft:item_used_on_block",
+      "trigger": "minecraft:any_block_use",
       "conditions": {
         "player": [
           {
@@ -17,6 +17,42 @@
                 "min": 1
               }
             }
+          },
+          {
+            "condition": "minecraft:value_check",
+            "value": {
+              "type": "minecraft:score",
+              "target": {
+                "type": "minecraft:fixed",
+                "name": "#smithed.actionbar.major"
+              },
+              "score": "load.status"
+            },
+            "range": 0
+          },
+          {
+            "condition": "minecraft:value_check",
+            "value": {
+              "type": "minecraft:score",
+              "target": {
+                "type": "minecraft:fixed",
+                "name": "#smithed.actionbar.minor"
+              },
+              "score": "load.status"
+            },
+            "range": 7
+          },
+          {
+            "condition": "minecraft:value_check",
+            "value": {
+              "type": "minecraft:score",
+              "target": {
+                "type": "minecraft:fixed",
+                "name": "#smithed.actionbar.patch"
+              },
+              "score": "load.status"
+            },
+            "range": 0
           }
         ],
         "location": [
@@ -25,7 +61,7 @@
             "predicate": {
               "dimension": "minecraft:overworld",
               "block": {
-                "tag": "minecraft:beds",
+                "blocks": "#minecraft:beds",
                 "state": {
                   "occupied": "false"
                 }
@@ -36,7 +72,7 @@
       }
     },
     "occupied": {
-      "trigger": "minecraft:item_used_on_block",
+      "trigger": "minecraft:any_block_use",
       "conditions": {
         "player": [
           {
@@ -52,89 +88,51 @@
                 "min": 1
               }
             }
-          }
-        ],
-        "location": [
-          {
-            "condition": "minecraft:location_check",
-            "predicate": {
-              "dimension": "minecraft:overworld",
-              "block": {
-                "tag": "minecraft:beds",
-                "state": {
-                  "occupied": "true"
-                }
-              }
-            }
-          }
-        ]
-      }
-    },
-    "unoccupied_empty": {
-      "trigger": "minecraft:item_used_on_block",
-      "conditions": {
-        "player": [
+          },
           {
             "condition": "minecraft:value_check",
             "value": {
               "type": "minecraft:score",
-              "target": "this",
-              "score": "smithed.actionbar.sneaking"
+              "target": {
+                "type": "minecraft:fixed",
+                "name": "#smithed.actionbar.major"
+              },
+              "score": "load.status"
             },
-            "range": {
-              "min": 1
-            }
-          }
-        ],
-        "item": {
-          "items": [
-            "minecraft:air"
-          ]
-        },
-        "location": [
-          {
-            "condition": "minecraft:location_check",
-            "predicate": {
-              "dimension": "minecraft:overworld",
-              "block": {
-                "tag": "minecraft:beds",
-                "state": {
-                  "occupied": "false"
-                }
-              }
-            }
-          }
-        ]
-      }
-    },
-    "occupied_empty": {
-      "trigger": "minecraft:item_used_on_block",
-      "conditions": {
-        "player": [
+            "range": 0
+          },
           {
             "condition": "minecraft:value_check",
             "value": {
               "type": "minecraft:score",
-              "target": "this",
-              "score": "smithed.actionbar.sneaking"
+              "target": {
+                "type": "minecraft:fixed",
+                "name": "#smithed.actionbar.minor"
+              },
+              "score": "load.status"
             },
-            "range": {
-              "min": 1
-            }
+            "range": 7
+          },
+          {
+            "condition": "minecraft:value_check",
+            "value": {
+              "type": "minecraft:score",
+              "target": {
+                "type": "minecraft:fixed",
+                "name": "#smithed.actionbar.patch"
+              },
+              "score": "load.status"
+            },
+            "range": 0
           }
         ],
-        "item": {
-          "items": [
-            "minecraft:air"
-          ]
-        },
         "location": [
           {
             "condition": "minecraft:location_check",
             "predicate": {
               "dimension": "minecraft:overworld",
               "block": {
-                "tag": "minecraft:beds",
+                "blocks": "#minecraft:beds",
                 "state": {
                   "occupied": "true"
                 }
@@ -148,12 +146,10 @@
   "requirements": [
     [
       "unoccupied",
-      "occupied",
-      "unoccupied_empty",
-      "occupied_empty"
+      "occupied"
     ]
   ],
   "rewards": {
-    "function": "smithed.actionbar:impl/vanilla/bed/clicked_bed"
+    "function": "smithed.actionbar:v0.7.0/vanilla/bed/clicked_bed"
   }
 }

--- a/smithed_libraries/packs/actionbar/data/smithed.actionbar/advancement/impl/vanilla/bed/clicked_bed.json
+++ b/smithed_libraries/packs/actionbar/data/smithed.actionbar/advancement/impl/vanilla/bed/clicked_bed.json
@@ -17,42 +17,6 @@
                 "min": 1
               }
             }
-          },
-          {
-            "condition": "minecraft:value_check",
-            "value": {
-              "type": "minecraft:score",
-              "target": {
-                "type": "minecraft:fixed",
-                "name": "#smithed.actionbar.major"
-              },
-              "score": "load.status"
-            },
-            "range": 0
-          },
-          {
-            "condition": "minecraft:value_check",
-            "value": {
-              "type": "minecraft:score",
-              "target": {
-                "type": "minecraft:fixed",
-                "name": "#smithed.actionbar.minor"
-              },
-              "score": "load.status"
-            },
-            "range": 7
-          },
-          {
-            "condition": "minecraft:value_check",
-            "value": {
-              "type": "minecraft:score",
-              "target": {
-                "type": "minecraft:fixed",
-                "name": "#smithed.actionbar.patch"
-              },
-              "score": "load.status"
-            },
-            "range": 0
           }
         ],
         "location": [
@@ -88,42 +52,6 @@
                 "min": 1
               }
             }
-          },
-          {
-            "condition": "minecraft:value_check",
-            "value": {
-              "type": "minecraft:score",
-              "target": {
-                "type": "minecraft:fixed",
-                "name": "#smithed.actionbar.major"
-              },
-              "score": "load.status"
-            },
-            "range": 0
-          },
-          {
-            "condition": "minecraft:value_check",
-            "value": {
-              "type": "minecraft:score",
-              "target": {
-                "type": "minecraft:fixed",
-                "name": "#smithed.actionbar.minor"
-              },
-              "score": "load.status"
-            },
-            "range": 7
-          },
-          {
-            "condition": "minecraft:value_check",
-            "value": {
-              "type": "minecraft:score",
-              "target": {
-                "type": "minecraft:fixed",
-                "name": "#smithed.actionbar.patch"
-              },
-              "score": "load.status"
-            },
-            "range": 0
           }
         ],
         "location": [
@@ -150,6 +78,6 @@
     ]
   ],
   "rewards": {
-    "function": "smithed.actionbar:v0.7.0/vanilla/bed/clicked_bed"
+    "function": "smithed.actionbar:impl/vanilla/bed/clicked_bed"
   }
 }

--- a/smithed_libraries/packs/actionbar/data/smithed.actionbar/advancement/impl/vanilla/bed/slept_in_bed.json
+++ b/smithed_libraries/packs/actionbar/data/smithed.actionbar/advancement/impl/vanilla/bed/slept_in_bed.json
@@ -3,12 +3,51 @@
     "requirement": {
       "trigger": "minecraft:slept_in_bed",
       "conditions": {
-        "location": [
+        "player": [
           {
-            "condition": "minecraft:location_check",
+            "condition": "minecraft:entity_properties",
+            "entity": "this",
             "predicate": {
-              "dimension": "minecraft:overworld"
+              "minecraft:location": {
+                "dimension": "minecraft:overworld"
+              }
             }
+          },
+          {
+            "condition": "minecraft:value_check",
+            "value": {
+              "type": "minecraft:score",
+              "target": {
+                "type": "minecraft:fixed",
+                "name": "#smithed.actionbar.major"
+              },
+              "score": "load.status"
+            },
+            "range": 0
+          },
+          {
+            "condition": "minecraft:value_check",
+            "value": {
+              "type": "minecraft:score",
+              "target": {
+                "type": "minecraft:fixed",
+                "name": "#smithed.actionbar.minor"
+              },
+              "score": "load.status"
+            },
+            "range": 7
+          },
+          {
+            "condition": "minecraft:value_check",
+            "value": {
+              "type": "minecraft:score",
+              "target": {
+                "type": "minecraft:fixed",
+                "name": "#smithed.actionbar.patch"
+              },
+              "score": "load.status"
+            },
+            "range": 0
           }
         ]
       }

--- a/smithed_libraries/packs/actionbar/data/smithed.actionbar/advancement/impl/vanilla/bed/slept_in_bed.json
+++ b/smithed_libraries/packs/actionbar/data/smithed.actionbar/advancement/impl/vanilla/bed/slept_in_bed.json
@@ -12,42 +12,6 @@
                 "dimension": "minecraft:overworld"
               }
             }
-          },
-          {
-            "condition": "minecraft:value_check",
-            "value": {
-              "type": "minecraft:score",
-              "target": {
-                "type": "minecraft:fixed",
-                "name": "#smithed.actionbar.major"
-              },
-              "score": "load.status"
-            },
-            "range": 0
-          },
-          {
-            "condition": "minecraft:value_check",
-            "value": {
-              "type": "minecraft:score",
-              "target": {
-                "type": "minecraft:fixed",
-                "name": "#smithed.actionbar.minor"
-              },
-              "score": "load.status"
-            },
-            "range": 7
-          },
-          {
-            "condition": "minecraft:value_check",
-            "value": {
-              "type": "minecraft:score",
-              "target": {
-                "type": "minecraft:fixed",
-                "name": "#smithed.actionbar.patch"
-              },
-              "score": "load.status"
-            },
-            "range": 0
           }
         ]
       }

--- a/smithed_libraries/packs/actionbar/data/smithed.actionbar/advancement/impl/vanilla/container/clicked_lockable_block.json
+++ b/smithed_libraries/packs/actionbar/data/smithed.actionbar/advancement/impl/vanilla/container/clicked_lockable_block.json
@@ -17,42 +17,6 @@
                 "min": 1
               }
             }
-          },
-          {
-            "condition": "minecraft:value_check",
-            "value": {
-              "type": "minecraft:score",
-              "target": {
-                "type": "minecraft:fixed",
-                "name": "#smithed.actionbar.major"
-              },
-              "score": "load.status"
-            },
-            "range": 0
-          },
-          {
-            "condition": "minecraft:value_check",
-            "value": {
-              "type": "minecraft:score",
-              "target": {
-                "type": "minecraft:fixed",
-                "name": "#smithed.actionbar.minor"
-              },
-              "score": "load.status"
-            },
-            "range": 7
-          },
-          {
-            "condition": "minecraft:value_check",
-            "value": {
-              "type": "minecraft:score",
-              "target": {
-                "type": "minecraft:fixed",
-                "name": "#smithed.actionbar.patch"
-              },
-              "score": "load.status"
-            },
-            "range": 0
           }
         ],
         "location": [
@@ -60,61 +24,23 @@
             "condition": "minecraft:location_check",
             "predicate": {
               "block": {
-                "blocks": "#smithed.actionbar:v0.7.0/lockable"
+                "blocks": "#smithed.actionbar:impl/lockable"
               }
             }
           }
         ]
       }
     },
-
     "click_empty": {
       "trigger": "minecraft:default_block_use",
       "conditions": {
-        "player": [
-          {
-            "condition": "minecraft:value_check",
-            "value": {
-              "type": "minecraft:score",
-              "target": {
-                "type": "minecraft:fixed",
-                "name": "#smithed.actionbar.major"
-              },
-              "score": "load.status"
-            },
-            "range": 0
-          },
-          {
-            "condition": "minecraft:value_check",
-            "value": {
-              "type": "minecraft:score",
-              "target": {
-                "type": "minecraft:fixed",
-                "name": "#smithed.actionbar.minor"
-              },
-              "score": "load.status"
-            },
-            "range": 7
-          },
-          {
-            "condition": "minecraft:value_check",
-            "value": {
-              "type": "minecraft:score",
-              "target": {
-                "type": "minecraft:fixed",
-                "name": "#smithed.actionbar.patch"
-              },
-              "score": "load.status"
-            },
-            "range": 0
-          }
-        ],
+        "player": [],
         "location": [
           {
             "condition": "minecraft:location_check",
             "predicate": {
               "block": {
-                "blocks": "#smithed.actionbar:v0.7.0/lockable"
+                "blocks": "#smithed.actionbar:impl/lockable"
               }
             }
           }
@@ -123,6 +49,6 @@
     }
   },
   "rewards": {
-    "function": "smithed.actionbar:v0.7.0/vanilla/container/clicked_lockable_block"
+    "function": "smithed.actionbar:impl/vanilla/container/clicked_lockable_block"
   }
 }

--- a/smithed_libraries/packs/actionbar/data/smithed.actionbar/advancement/impl/vanilla/container/clicked_lockable_block.json
+++ b/smithed_libraries/packs/actionbar/data/smithed.actionbar/advancement/impl/vanilla/container/clicked_lockable_block.json
@@ -1,7 +1,7 @@
 {
   "criteria": {
     "click_no_sneak": {
-      "trigger": "minecraft:item_used_on_block",
+      "trigger": "minecraft:any_block_use",
       "conditions": {
         "player": [
           {
@@ -17,6 +17,42 @@
                 "min": 1
               }
             }
+          },
+          {
+            "condition": "minecraft:value_check",
+            "value": {
+              "type": "minecraft:score",
+              "target": {
+                "type": "minecraft:fixed",
+                "name": "#smithed.actionbar.major"
+              },
+              "score": "load.status"
+            },
+            "range": 0
+          },
+          {
+            "condition": "minecraft:value_check",
+            "value": {
+              "type": "minecraft:score",
+              "target": {
+                "type": "minecraft:fixed",
+                "name": "#smithed.actionbar.minor"
+              },
+              "score": "load.status"
+            },
+            "range": 7
+          },
+          {
+            "condition": "minecraft:value_check",
+            "value": {
+              "type": "minecraft:score",
+              "target": {
+                "type": "minecraft:fixed",
+                "name": "#smithed.actionbar.patch"
+              },
+              "score": "load.status"
+            },
+            "range": 0
           }
         ],
         "location": [
@@ -24,29 +60,61 @@
             "condition": "minecraft:location_check",
             "predicate": {
               "block": {
-                "tag": "smithed.actionbar:impl/lockable"
+                "blocks": "#smithed.actionbar:v0.7.0/lockable"
               }
             }
           }
         ]
       }
     },
+
     "click_empty": {
-      "trigger": "minecraft:item_used_on_block",
+      "trigger": "minecraft:default_block_use",
       "conditions": {
         "player": [
+          {
+            "condition": "minecraft:value_check",
+            "value": {
+              "type": "minecraft:score",
+              "target": {
+                "type": "minecraft:fixed",
+                "name": "#smithed.actionbar.major"
+              },
+              "score": "load.status"
+            },
+            "range": 0
+          },
+          {
+            "condition": "minecraft:value_check",
+            "value": {
+              "type": "minecraft:score",
+              "target": {
+                "type": "minecraft:fixed",
+                "name": "#smithed.actionbar.minor"
+              },
+              "score": "load.status"
+            },
+            "range": 7
+          },
+          {
+            "condition": "minecraft:value_check",
+            "value": {
+              "type": "minecraft:score",
+              "target": {
+                "type": "minecraft:fixed",
+                "name": "#smithed.actionbar.patch"
+              },
+              "score": "load.status"
+            },
+            "range": 0
+          }
         ],
-        "item": {
-          "items": [
-            "minecraft:air"
-          ]
-        },
         "location": [
           {
             "condition": "minecraft:location_check",
             "predicate": {
               "block": {
-                "tag": "smithed.actionbar:impl/lockable"
+                "blocks": "#smithed.actionbar:v0.7.0/lockable"
               }
             }
           }
@@ -54,13 +122,7 @@
       }
     }
   },
-  "requirements": [
-    [
-      "click_no_sneak",
-      "click_empty"
-    ]
-  ],
   "rewards": {
-    "function": "smithed.actionbar:impl/vanilla/container/clicked_lockable_block"
+    "function": "smithed.actionbar:v0.7.0/vanilla/container/clicked_lockable_block"
   }
 }

--- a/smithed_libraries/packs/actionbar/data/smithed.actionbar/function/impl/display.mcfunction
+++ b/smithed_libraries/packs/actionbar/data/smithed.actionbar/function/impl/display.mcfunction
@@ -5,7 +5,7 @@
 
 # yes, if you define raw and json, you'll get 2 messages
 #  i left this "bug" in so that folks catch this in testing
-execute if data storage smithed.actionbar:input message.raw run title @s actionbar {"storage": "smithed.actionbar:input", "nbt": "message.raw"}
+execute if data storage smithed.actionbar:input message.raw run title @s actionbar {"storage": "smithed.actionbar:input", "nbt": "message.raw", "interpret": true}
 execute if data storage smithed.actionbar:input message.json run title @s actionbar {"storage": "smithed.actionbar:input", "nbt": "message.json", "interpret": true}
 
 # copy freeze w/ bounds checking

--- a/smithed_libraries/packs/actionbar/data/smithed.actionbar/function/impl/vanilla/bed/clicked_bed.mcfunction
+++ b/smithed_libraries/packs/actionbar/data/smithed.actionbar/function/impl/vanilla/bed/clicked_bed.mcfunction
@@ -5,7 +5,6 @@
 
 # check if the player entered the bed
 tag @s[advancements={smithed.actionbar:impl/vanilla/bed/clicked_bed={occupied=true}}] add smithed.actionbar.occupied
-tag @s[advancements={smithed.actionbar:impl/vanilla/bed/clicked_bed={occupied_empty=true}}] add smithed.actionbar.occupied
 tag @s[advancements={smithed.actionbar:impl/vanilla/bed/slept_in_bed={requirement=true}}] add smithed.actionbar.sleeping
 
 advancement revoke @s only smithed.actionbar:impl/vanilla/bed/clicked_bed

--- a/smithed_libraries/packs/actionbar/data/smithed.actionbar/function/impl/vanilla/container/check_double_chest_lock/east.mcfunction
+++ b/smithed_libraries/packs/actionbar/data/smithed.actionbar/function/impl/vanilla/container/check_double_chest_lock/east.mcfunction
@@ -4,8 +4,8 @@
 # run from vanilla/container/check_double_chest_lock
 
 # check if the other chest is locked
-execute if block ~ ~ ~ #smithed.actionbar:impl/chests[type=right] store success score $locked smithed.actionbar.temp if data block ~ ~ ~-1 Lock
-execute if block ~ ~ ~ #smithed.actionbar:impl/chests[type=left] store success score $locked smithed.actionbar.temp if data block ~ ~ ~1 Lock
+execute if block ~ ~ ~ #smithed.actionbar:impl/chests[type=right] store success score $locked smithed.actionbar.temp if data block ~ ~ ~-1 lock
+execute if block ~ ~ ~ #smithed.actionbar:impl/chests[type=left] store success score $locked smithed.actionbar.temp if data block ~ ~ ~1 lock
 
 # store info for locked container
 execute if score $locked smithed.actionbar.temp matches 1 if block ~ ~ ~ #smithed.actionbar:impl/chests[type=right] run data modify storage smithed.actionbar:data block set from block ~ ~ ~-1 {}

--- a/smithed_libraries/packs/actionbar/data/smithed.actionbar/function/impl/vanilla/container/check_double_chest_lock/north.mcfunction
+++ b/smithed_libraries/packs/actionbar/data/smithed.actionbar/function/impl/vanilla/container/check_double_chest_lock/north.mcfunction
@@ -4,8 +4,8 @@
 # run from vanilla/container/check_double_chest_lock
 
 # check if the other chest is locked
-execute if block ~ ~ ~ #smithed.actionbar:impl/chests[type=right] store success score $locked smithed.actionbar.temp if data block ~-1 ~ ~ Lock
-execute if block ~ ~ ~ #smithed.actionbar:impl/chests[type=left] store success score $locked smithed.actionbar.temp if data block ~1 ~ ~ Lock
+execute if block ~ ~ ~ #smithed.actionbar:impl/chests[type=right] store success score $locked smithed.actionbar.temp if data block ~-1 ~ ~ lock
+execute if block ~ ~ ~ #smithed.actionbar:impl/chests[type=left] store success score $locked smithed.actionbar.temp if data block ~1 ~ ~ lock
 
 # store info for locked container
 execute if score $locked smithed.actionbar.temp matches 1 if block ~ ~ ~ #smithed.actionbar:impl/chests[type=right] run data modify storage smithed.actionbar:data block set from block ~-1 ~ ~ {}

--- a/smithed_libraries/packs/actionbar/data/smithed.actionbar/function/impl/vanilla/container/check_double_chest_lock/south.mcfunction
+++ b/smithed_libraries/packs/actionbar/data/smithed.actionbar/function/impl/vanilla/container/check_double_chest_lock/south.mcfunction
@@ -4,8 +4,8 @@
 # run from vanilla/container/check_double_chest_lock
 
 # check if the other chest is locked
-execute if block ~ ~ ~ #smithed.actionbar:impl/chests[type=right] store success score $locked smithed.actionbar.temp if data block ~1 ~ ~ Lock
-execute if block ~ ~ ~ #smithed.actionbar:impl/chests[type=left] store success score $locked smithed.actionbar.temp if data block ~-1 ~ ~ Lock
+execute if block ~ ~ ~ #smithed.actionbar:impl/chests[type=right] store success score $locked smithed.actionbar.temp if data block ~1 ~ ~ lock
+execute if block ~ ~ ~ #smithed.actionbar:impl/chests[type=left] store success score $locked smithed.actionbar.temp if data block ~-1 ~ ~ lock
 
 # store info for locked container
 execute if score $locked smithed.actionbar.temp matches 1 if block ~ ~ ~ #smithed.actionbar:impl/chests[type=right] run data modify storage smithed.actionbar:data block set from block ~1 ~ ~ {}

--- a/smithed_libraries/packs/actionbar/data/smithed.actionbar/function/impl/vanilla/container/check_double_chest_lock/west.mcfunction
+++ b/smithed_libraries/packs/actionbar/data/smithed.actionbar/function/impl/vanilla/container/check_double_chest_lock/west.mcfunction
@@ -4,8 +4,8 @@
 # run from vanilla/container/check_double_chest_lock
 
 # check if the other chest is locked
-execute if block ~ ~ ~ #smithed.actionbar:impl/chests[type=right] store success score $locked smithed.actionbar.temp if data block ~ ~ ~1 Lock
-execute if block ~ ~ ~ #smithed.actionbar:impl/chests[type=left] store success score $locked smithed.actionbar.temp if data block ~ ~ ~-1 Lock
+execute if block ~ ~ ~ #smithed.actionbar:impl/chests[type=right] store success score $locked smithed.actionbar.temp if data block ~ ~ ~1 lock
+execute if block ~ ~ ~ #smithed.actionbar:impl/chests[type=left] store success score $locked smithed.actionbar.temp if data block ~ ~ ~-1 lock
 
 # store info for locked container
 execute if score $locked smithed.actionbar.temp matches 1 if block ~ ~ ~ #smithed.actionbar:impl/chests[type=right] run data modify storage smithed.actionbar:data block set from block ~ ~ ~1 {}

--- a/smithed_libraries/packs/actionbar/data/smithed.actionbar/function/impl/vanilla/container/check_lock.mcfunction
+++ b/smithed_libraries/packs/actionbar/data/smithed.actionbar/function/impl/vanilla/container/check_lock.mcfunction
@@ -5,7 +5,7 @@
 
 # check if the block is locked
 scoreboard players set $locked smithed.actionbar.temp 0
-execute store success score $locked smithed.actionbar.temp if data block ~ ~ ~ Lock
+execute store success score $locked smithed.actionbar.temp if data block ~ ~ ~ lock
 execute if score $locked smithed.actionbar.temp matches 1 run data modify storage smithed.actionbar:data block set from block ~ ~ ~ {}
 execute if score $locked smithed.actionbar.temp matches 0 if block ~ ~ ~ #smithed.actionbar:impl/chests unless block ~ ~ ~ #smithed.actionbar:impl/chests[type=single] run function smithed.actionbar:impl/vanilla/container/check_double_chest_lock
 

--- a/smithed_libraries/packs/crafter/beet.yaml
+++ b/smithed_libraries/packs/crafter/beet.yaml
@@ -2,7 +2,7 @@ extend: "@smithed_libraries/common.yaml"
 
 id: smithed.crafter
 name: Smithed Crafter
-version: "0.10.0"
+version: "0.11.0"
 description: Native Library for Smithed
 author: TheNuclearNexus
 minecraft: "1.21"
@@ -38,5 +38,5 @@ output: dist
 
 meta:
   depends_on: # used for metadata
-    custom-block: "0.10.0"
-  minecraft_version: "26.1"
+    custom-block: "0.11.0"
+  minecraft_version: "26.2"

--- a/smithed_libraries/packs/custom-block/beet.yaml
+++ b/smithed_libraries/packs/custom-block/beet.yaml
@@ -2,7 +2,7 @@ extend: "@smithed_libraries/common.yaml"
 
 id: smithed.custom_block
 name: Smithed Custom Block
-version: "0.10.0"
+version: "0.11.0"
 description: Native Custom Block Library for Smithed
 
 data_pack:


### PR DESCRIPTION
## Overview

Fixes #62

This PR fixes vanilla Actionbar block interaction detection and ports the
affected Actionbar advancements to the Minecraft 26.2 data pack format.

## Problem

The Actionbar library currently uses `minecraft:item_used_on_block` to
detect interactions with vanilla blocks.

This is too restrictive for reproducing vanilla Actionbar behavior.
For example, right-clicking a lockable block with a stick does not trigger
`item_used_on_block`, while placing a block does.

As a result, some legitimate block interactions do not produce the expected
Actionbar message.

## Changes

- Replace `minecraft:item_used_on_block` with `minecraft:any_block_use`
  where generic block interaction is required.
- Remove redundant empty-hand criteria using `minecraft:air`.
- Remove the now-unnecessary `requirements` sections where only a single
  criterion remains.
- Keep separate `occupied` and `unoccupied` criteria for beds.
- Update block predicates from `tag` to `blocks`.
- Update the legacy `Lock` block data field to `lock`.
- Remove the obsolete top-level `conditions.location` from
  `slept_in_bed.json`.

## Bed interactions

`clicked_bed.json` previously had four criteria:

- `unoccupied`
- `occupied`
- `unoccupied_empty`
- `occupied_empty`

The empty-hand criteria were removed because `any_block_use` can detect
the block interaction directly.

The advancement now has two criteria:

- `unoccupied`
- `occupied`

This preserves the distinction needed by the Actionbar implementation
while avoiding duplicate interaction criteria.

## Lockable blocks

`clicked_lockable_block.json` now uses a single `any_block_use` criterion.

It checks that:

- the player is not sneaking;
- the Actionbar library version is loaded; and
- the interacted block belongs to the `lockable` block tag.

The previous empty-hand criterion and requirements section are no longer
needed.

## 26.2 compatibility

The affected block predicates have been updated from:

    "tag": "..."

to:

    "blocks": "#..."

The container lock check has also been updated from the legacy `Lock`
block data field to the current `lock` field.

The `slept_in_bed` advancement no longer uses the obsolete top-level
`conditions.location` field.

## Testing

Tested the Actionbar interactions for:

- Right-clicking lockable blocks with a stick.
- Placing blocks against lockable blocks.
- Empty-hand interactions.
- Sneaking interactions.
- Occupied beds.
- Unoccupied beds.
- Sleeping in beds in the Overworld.

The Actionbar library also builds successfully with Beet.